### PR TITLE
Multi-arch docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+TAG := ugosan/i2p:2.50.0-beta
+
+ARM_TAG := $(TAG)-manifest-arm64v8
+AMD_TAG := $(TAG)-manifest-amd64
+
+all: build push pull
+
+build:
+	@echo "\n::: Building $(ARM_TAG)"
+	docker build --push -f Dockerfile --platform linux/arm64/v8 --tag $(ARM_TAG) .
+	@echo "\n::: Building $(AMD_TAG)"
+	docker build --push -f Dockerfile --platform linux/amd64 --tag $(AMD_TAG) .
+	docker manifest create $(TAG) --amend $(ARM_TAG) --amend $(AMD_TAG)
+	@echo "\n::: Building done!"
+
+push:
+	docker manifest push $(TAG) --purge
+
+pull:
+	docker pull $(TAG)
+


### PR DESCRIPTION
I tried to run i2p on my raspberry pi via docker and realized the image was x86 only, so here is a Makefile for building a multi-arch image, it will build two images (currently `amd64` and `arm64/v8`) and then join them under a single mainfest. 

<img width="1097" alt="imagen" src="https://github.com/diva-exchange/i2p/assets/17125/8ae50835-88a9-4ae7-951a-2f489a00fb9a">

Just change the TAG and `make`